### PR TITLE
n the fetchPaginatedDataAsStream method, we create a stream of page n…

### DIFF
--- a/src/main/java/com/apptware/interview/stream/PaginationService.java
+++ b/src/main/java/com/apptware/interview/stream/PaginationService.java
@@ -5,6 +5,7 @@ import java.util.List;
 public interface PaginationService {
 
   int FULL_DATA_SIZE = 10000;
+  int PAGE_SIZE = 100;
 
   List<String> getPaginatedData(int page, int pageSize);
 }

--- a/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
+++ b/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
@@ -3,10 +3,15 @@ package com.apptware.interview.stream.impl;
 import com.apptware.interview.stream.DataReader;
 import com.apptware.interview.stream.PaginationService;
 import jakarta.annotation.Nonnull;
+
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import static com.apptware.interview.stream.PaginationService.FULL_DATA_SIZE;
+import static com.apptware.interview.stream.PaginationService.PAGE_SIZE;
 
 @Slf4j
 @Service
@@ -34,8 +39,10 @@ class DataReaderImpl implements DataReader {
     // Placeholder for paginated data fetching logic
     // The candidate will add the actual implementation here
 
-    Stream<String> dataStream =
-        Stream.empty(); // Temporary, will be replaced by the actual data stream
+    Stream<String> dataStream = Stream.iterate(1, n -> n + 1)
+            .limit((FULL_DATA_SIZE + PAGE_SIZE - 1) / PAGE_SIZE)
+            .flatMap(page -> paginationService.getPaginatedData(page, PAGE_SIZE).stream());
+
     return dataStream.peek(item -> log.info("Fetched Item: {}", item));
   }
 }


### PR DESCRIPTION
 In the fetchPaginatedDataAsStream method, we create a stream of page numbers using Stream.iterate. We had  calculated the total number of pages by dividing the total data size by the page size. The flatMap operation is used to flatten the lists returned from paginationService.getPaginatedData(page, PAGE_SIZE) into a single stream.